### PR TITLE
Remove PAYLOADTYPE_LINKS

### DIFF
--- a/lib/odata/json.js
+++ b/lib/odata/json.js
@@ -421,9 +421,6 @@ function addMinimalMetadataToJsonPayload(data, model, recognizeDates) {
 
         case PAYLOADTYPE_SVCDOC:
             return data;
-
-        case PAYLOADTYPE_LINKS:
-            return data;
     }
 
     return data;


### PR DESCRIPTION
`/$links` is pruned in OData4. We need to remove `PAYLOADTYPE_LINKS`. Also, this variable is not defined and will cause an error. See http://docs.oasis-open.org/odata/new-in-odata/v4.0/new-in-odata-v4.0.pdf
> 3.1.4 Pruned: /$links/
The old syntax of inserting a /$links/ segment between an entity and one of its navigation
properties has been dropped as the more flexible approach of appending /$ref can also
applied here.