### PR TITLE
Return the Content-ID value in batch responses by copying from partHeaders to response.headers

### DIFF
--- a/lib/odata/batch.js
+++ b/lib/odata/batch.js
@@ -147,6 +147,10 @@ function readBatch(text, context) {
             readLine(text, context);
             // Read the response
             var response = readResponse(text, context, delimiter);
+            // Copy Content-ID header from partHeaders if necessary
+            if (!response.headers["Content-ID"] && partHeaders["Content-ID"]) {
+                response.headers["Content-ID"] = partHeaders["Content-ID"];
+            }
             try {
                 if (response.statusCode >= 200 && response.statusCode <= 299) {
                     partHandler(context.handlerContext).read(response, context.handlerContext);

--- a/tests/odata-batch-functional-tests.js
+++ b/tests/odata-batch-functional-tests.js
@@ -30,8 +30,9 @@
         var expected = 0;
         $.each(batchRequests, function (_, batchRequest) {
             // 2 assertions per request: response code and data
+            // + 1 assertion per change request for Content-ID header
             if (batchRequest.__changeRequests) {
-                expected += batchRequest.__changeRequests.length * 2;
+                expected += batchRequest.__changeRequests.length * 3;
             } else {
                 expected += 2;
             }
@@ -71,6 +72,7 @@
         forEachAsync(changeRequests, function (index, changeRequest, doneOne) {
             var httpOperation = changeRequest.method + " " + changeRequest.requestUri;
             var changeResponse = changeResponses[index];
+            djstest.assertAreEqual(changeResponse.headers["Content-ID"], changeRequest.headers["Content-ID"], "Verify Content-ID header");
 
             if (changeRequest.method == "POST") {
                 djstest.assertAreEqual(changeResponse.statusCode, httpStatusCode.created, "Verify response code for: " + httpOperation);

--- a/tests/odata-batch-tests.js
+++ b/tests/odata-batch-tests.js
@@ -319,6 +319,7 @@ Content-Type: multipart/mixed; boundary=changesetresponse_905a1494-fd76-4846-93f
 --changesetresponse_905a1494-fd76-4846-93f9-a3431f0bf5a2\r\n\
 Content-Type: application/http\r\n\
 Content-Transfer-Encoding: binary\r\n\
+Content-ID: 1\r\n\
 \r\n\
 HTTP/1.1 201 OK\r\n\
 OData-Version: 4.0;\r\n\
@@ -331,6 +332,7 @@ Location: http://localhost:4002/tests/endpoints/FoodStoreDataServiceV4.svc/Categ
 --changesetresponse_905a1494-fd76-4846-93f9-a3431f0bf5a2\r\n\
 Content-Type: application/http\r\n\
 Content-Transfer-Encoding: binary\r\n\
+Content-ID: 2\r\n\
 \r\n\
 HTTP/1.1 204 No Content\r\n\
 X-Content-Type-Options: nosniff\r\n\
@@ -357,6 +359,7 @@ Content-Type: multipart/mixed; boundary=changesetresponse_92cc2ae8-a5f2-47fc-aaa
 --changesetresponse_92cc2ae8-a5f2-47fc-aaa3-1ff9e7453b07\r\n\
 Content-Type: application/http\r\n\
 Content-Transfer-Encoding: binary\r\n\
+Content-ID: 3\r\n\
 \r\n\
 HTTP/1.1 201 OK\r\n\
 OData-Version: 4.0;\r\n\
@@ -369,6 +372,7 @@ Location: http://localhost:4002/tests/endpoints/FoodStoreDataServiceV4.svc/Categ
 --changesetresponse_92cc2ae8-a5f2-47fc-aaa3-1ff9e7453b07\r\n\
 Content-Type: application/http\r\n\
 Content-Transfer-Encoding: binary\r\n\
+Content-ID: 4\r\n\
 \r\n\
 HTTP/1.1 204 No Content\r\n\
 X-Content-Type-Options: nosniff\r\n\
@@ -394,7 +398,9 @@ OData-Version: 4.0;\r\n\
             
             djstest.assertAreEqual(batchResponses[0].data, undefined, "No data defined for batch response 1");
             djstest.assertAreEqual(changesetResponses[0].headers["Location"], "http://localhost:4002/tests/endpoints/FoodStoreDataServiceV4.svc/Categories(42)", "part 1 of the changeset response of the response 1 was read");
+            djstest.assertAreEqual(changesetResponses[0].headers["Content-ID"], "1", "part 1 Content-ID header of the changeset response of the response 1 was read");
             djstest.assertAreEqual(changesetResponses[0].data["CategoryID"], 42, "part 1 data of the changeset response of the response 1 was read");
+            djstest.assertAreEqual(changesetResponses[1].headers["Content-ID"], "2", "part 2 Content-ID header of the changeset response of the response 1 was read");
             djstest.assertAreEqual(changesetResponses[1].data, undefined, "No data defined for no content only response in part 2 of the changeset response of the response 1");
             
             djstest.assertAreEqual(batchResponses[1].headers["Location"], "http://localhost:4002/tests/endpoints/FoodStoreDataServiceV4.svc/Categories(41)", "response 2 was read");
@@ -402,7 +408,9 @@ OData-Version: 4.0;\r\n\
             
             djstest.assertAreEqual(batchResponses[2].data, undefined, "No data defined for");
             djstest.assertAreEqual(changesetResponses3[0].headers["Location"], "http://localhost:4002/tests/endpoints/FoodStoreDataServiceV4.svc/Categories(43)", "part 1 of the changeset response of the response 3 was read");
+            djstest.assertAreEqual(changesetResponses3[0].headers["Content-ID"], "3", "part 1 Content-ID header of the changeset response of the response 3 was read");
             djstest.assertAreEqual(changesetResponses3[0].data["CategoryID"], 43, "part 1 data of the changeset response of the response 3 was read");
+            djstest.assertAreEqual(changesetResponses3[1].headers["Content-ID"], "4", "part 2 Content-ID header of the changeset response of the response 3 was read");
             djstest.assertAreEqual(changesetResponses3[1].data, undefined, "No data defined for no content only response in part 2 of the changeset response of the response 3");
             djstest.done();
         }, null, window.odatajs.oData.batch.batchHandler, MockHttpClient);


### PR DESCRIPTION
See https://github.com/tschettler/breeze-odata4/issues/85

In batch responses, Content-ID values are required to associate responses to their requests.
In odata4, the Content-ID header is a mime part header instead of a http response header, but mime part headers aren't returned, so the Content-ID values are lost.

This PR is a simple fix that makes the Content-ID available by copying it the Content-ID value from the part headers to the http response headers.